### PR TITLE
feat: renamed feeder pull to bottom and push to top

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -11,7 +11,7 @@ from frc3484.controls import Input, XboxControllerMap
 from frc3484.controls import XboxControllerMap as ControllerMap
 from frc3484.vision import SC_CameraConfig
 
-from src.datatypes import IntakePosition
+from src.datatypes import IntakePosition, FeederSpeed
 
 import numpy as np
 
@@ -317,54 +317,54 @@ class FeederSubsystemConstants:
     """
     Constants for the Feeder Subsystem
     """
-    PULL_MOTOR_CONFIG: SC_MotorConfig = SC_MotorConfig(
+    BOTTOM_MOTOR_CONFIG: SC_MotorConfig = SC_MotorConfig(
         can_id=50,
         inverted=False,
         can_bus_name="rio",
         neutral_mode=NeutralModeValue.BRAKE, 
         motor_type="minion",
     )
-    PULL_PID_CONFIG: SC_PIDConfig = SC_PIDConfig(
+    BOTTOM_PID_CONFIG: SC_PIDConfig = SC_PIDConfig(
         Kp=0.052243,
         Ki=0.0,
         Kd=0.0,
         Kf=0.0,
     )
-    PULL_FEED_FORWARD_CONFIG: SC_AngularFeedForwardConfig = SC_AngularFeedForwardConfig(
+    BOTTOM_FEED_FORWARD_CONFIG: SC_AngularFeedForwardConfig = SC_AngularFeedForwardConfig(
         G=0.0,
         S=0.0,
         V=0.092712,
         A=0.78117
     )
-    PULL_MOTOR_GEAR_RATIO: float = 1.0
-    PULL_MOTOR_TOLERANCE: float = 0.0
+    BOTTOM_MOTOR_GEAR_RATIO: float = 1.0
+    BOTTOM_MOTOR_TOLERANCE: float = 0.0
 
-    PUSH_MOTOR_CONFIG: SC_MotorConfig = SC_MotorConfig(
+    TOP_MOTOR_CONFIG: SC_MotorConfig = SC_MotorConfig(
         can_id=51,
         inverted=True,
         can_bus_name="rio",
         neutral_mode=NeutralModeValue.BRAKE, 
         motor_type="minion",
     )
-    PUSH_PID_CONFIG: SC_PIDConfig = SC_PIDConfig(
+    TOP_PID_CONFIG: SC_PIDConfig = SC_PIDConfig(
         Kp=0.12976,
         Ki=0.0,
         Kd=0.0,
         Kf=0.0,
     )
-    PUSH_FEED_FORWARD_CONFIG: SC_AngularFeedForwardConfig = SC_AngularFeedForwardConfig(
+    TOP_FEED_FORWARD_CONFIG: SC_AngularFeedForwardConfig = SC_AngularFeedForwardConfig(
         G=0.0,
         S=0.25347,
         V=0.11071,
         A=0.03327
     )
-    PUSH_MOTOR_GEAR_RATIO: float = 1.0
-    PUSH_MOTOR_TOLERANCE: float = 0.0
+    TOP_MOTOR_GEAR_RATIO: float = 1.0
+    TOP_MOTOR_TOLERANCE: float = 0.0
 
     ENTRY_PIECE_SENSOR_ID: int = 1
     EXIT_PIECE_SENSOR_ID: int = 0
 
-    FEED_SPEED: tuple[SC_LauncherSpeed, SC_LauncherSpeed] = (
+    FEED_SPEED: FeederSpeed = FeederSpeed(
         SC_LauncherSpeed(
             speed=4000,
             power=0
@@ -375,7 +375,7 @@ class FeederSubsystemConstants:
         )
     )
 
-    REMOVE_PIECE_VELOCITY: tuple[SC_LauncherSpeed, SC_LauncherSpeed] = (
+    REMOVE_PIECE_VELOCITY: FeederSpeed = FeederSpeed(
         SC_LauncherSpeed(
             speed=0.0, 
             power=-0.5
@@ -383,6 +383,17 @@ class FeederSubsystemConstants:
         SC_LauncherSpeed(
             speed=0.0, 
             power=-0.5
+        )
+    )
+
+    STOP_VELOCITY: FeederSpeed = FeederSpeed(
+        SC_LauncherSpeed(
+            speed=0.0,
+            power=0.0
+        ),
+        SC_LauncherSpeed(
+            speed=0.0,
+            power=0.0
         )
     )
 

--- a/src/subsystems/feeder_subsystem.py
+++ b/src/subsystems/feeder_subsystem.py
@@ -9,6 +9,7 @@ from wpimath.units import volts
 from wpilib import DriverStation
 
 from src.constants import FeederSubsystemConstants
+from src.datatypes import FeederSpeed
 
 class FeederSubsystem(Subsystem):
     """
@@ -20,20 +21,20 @@ class FeederSubsystem(Subsystem):
         super().__init__()
 
         # The series of belts that pull the fuel into the turret
-        self._pull_motor: VelocityMotor = VelocityMotor(
-            FeederSubsystemConstants.PULL_MOTOR_CONFIG, 
-            FeederSubsystemConstants.PULL_PID_CONFIG, 
-            FeederSubsystemConstants.PULL_FEED_FORWARD_CONFIG, 
-            FeederSubsystemConstants.PULL_MOTOR_GEAR_RATIO, 
-            FeederSubsystemConstants.PULL_MOTOR_TOLERANCE
+        self._bottom_motor: VelocityMotor = VelocityMotor(
+            FeederSubsystemConstants.BOTTOM_MOTOR_CONFIG, 
+            FeederSubsystemConstants.BOTTOM_PID_CONFIG, 
+            FeederSubsystemConstants.BOTTOM_FEED_FORWARD_CONFIG, 
+            FeederSubsystemConstants.BOTTOM_MOTOR_GEAR_RATIO, 
+            FeederSubsystemConstants.BOTTOM_MOTOR_TOLERANCE
         )
         # The rollers at the top of the hopper that push the pieces up into the turret
-        self._push_motor: VelocityMotor = VelocityMotor(
-            FeederSubsystemConstants.PUSH_MOTOR_CONFIG, 
-            FeederSubsystemConstants.PUSH_PID_CONFIG, 
-            FeederSubsystemConstants.PUSH_FEED_FORWARD_CONFIG, 
-            FeederSubsystemConstants.PUSH_MOTOR_GEAR_RATIO, 
-            FeederSubsystemConstants.PUSH_MOTOR_TOLERANCE
+        self._top_motor: VelocityMotor = VelocityMotor(
+            FeederSubsystemConstants.TOP_MOTOR_CONFIG, 
+            FeederSubsystemConstants.TOP_PID_CONFIG, 
+            FeederSubsystemConstants.TOP_FEED_FORWARD_CONFIG, 
+            FeederSubsystemConstants.TOP_MOTOR_GEAR_RATIO, 
+            FeederSubsystemConstants.TOP_MOTOR_TOLERANCE
         )
         self._entry_piece_sensor: DigitalInput = DigitalInput(
             FeederSubsystemConstants.ENTRY_PIECE_SENSOR_ID
@@ -44,32 +45,32 @@ class FeederSubsystem(Subsystem):
 
         SmartDashboard.putBoolean("Indexer Diagnostics", False)
 
-        self._pull_target_velocity: SC_LauncherSpeed = SC_LauncherSpeed(0, 0)
-        self._push_target_velocity: SC_LauncherSpeed = SC_LauncherSpeed(0, 0)
+        self._bottom_target_velocity: SC_LauncherSpeed = SC_LauncherSpeed(0, 0)
+        self._top_target_velocity: SC_LauncherSpeed = SC_LauncherSpeed(0, 0)
 
-        self._pull_sys_id_routine: SysIdRoutine = SysIdRoutine(
+        self._bottom_sys_id_routine: SysIdRoutine = SysIdRoutine(
             SysIdRoutine.Config(
                 # Use default ramp rate (1 V/s) and timeout (10 s)
                 # Reduce dynamic voltage to 4 V to prevent brownout
                 stepVoltage=4.0
             ),
             SysIdRoutine.Mechanism(
-                self._set_pull_voltage,
-                self._log_pull_motor,
+                self._set_bottom_voltage,
+                self._log_bottom_motor,
                 self,
                 'feeder'
             )
         )
 
-        self._push_sys_id_routine: SysIdRoutine = SysIdRoutine(
+        self._top_sys_id_routine: SysIdRoutine = SysIdRoutine(
             SysIdRoutine.Config(
                 # Use default ramp rate (1 V/s) and timeout (10 s)
                 # Reduce dynamic voltage to 4 V to prevent brownout
                 stepVoltage=4.0
             ),
             SysIdRoutine.Mechanism(
-                self._set_push_voltage,
-                self._log_push_motor,
+                self._set_top_voltage,
+                self._log_top_motor,
                 self,
                 'feeder'
             )
@@ -83,28 +84,27 @@ class FeederSubsystem(Subsystem):
         Also prints diagnostics if enabled
         """
         if not DriverStation.isTest():
-            if self.has_piece() and self._pull_target_velocity.speed == 0 and self._pull_target_velocity.power == 0:
-                self._pull_motor.set_speed(FeederSubsystemConstants.REMOVE_PIECE_VELOCITY[0])
-                self._push_motor.set_speed(FeederSubsystemConstants.REMOVE_PIECE_VELOCITY[1])
+            if self.has_piece() and self._bottom_target_velocity == FeederSubsystemConstants.STOP_VELOCITY.bottom_speed and self._top_target_velocity == FeederSubsystemConstants.STOP_VELOCITY.top_speed:
+                self.set_velocity(FeederSubsystemConstants.REMOVE_PIECE_VELOCITY)
             else:
-                self._pull_motor.set_speed(self._pull_target_velocity)
-                self._push_motor.set_speed(self._push_target_velocity)
+                self.set_velocity(FeederSubsystemConstants.STOP_VELOCITY)
 
         if SmartDashboard.getBoolean("Indexer Diagnostics", False):
             self.print_diagnostics()
 
-    def set_velocity(self, velocity: tuple[SC_LauncherSpeed, SC_LauncherSpeed]) -> None:
+    def set_velocity(self, velocity: FeederSpeed) -> None:
         """
         Sets the velocity of the feeder's motors
 
         Args:
-            velocity (`tuple[SC_LauncherSpeed, SC_LauncherSpeed]`): the velocity and power to set the indexer to, the pull motor is first, and the second item is the push motor
-        """
-        self._pull_target_velocity = velocity[0]
-        self._pull_motor.set_speed(self._pull_target_velocity)
+            velocity (`FeederSpeed`): the velocity and power to set the feeder to
 
-        self._push_target_velocity = velocity[1]
-        self._push_motor.set_speed(self._push_target_velocity)
+        """
+        self._bottom_target_velocity = velocity.bottom_speed
+        self._bottom_motor.set_speed(self._bottom_target_velocity)
+
+        self._top_target_velocity = velocity.top_speed
+        self._top_motor.set_speed(self._top_target_velocity)
 
     def set_power(self, power: tuple[float, float]) -> None:  
         """
@@ -113,15 +113,21 @@ class FeederSubsystem(Subsystem):
         Args:
             power (`tup;e[float, float]`): the power to set the feeder to, where the first item is the pull motor and the second item is the push motor
         """
-        self._pull_motor.set_power(power[0])
-        self._push_motor.set_power(power[1])
+        self._bottom_motor.set_power(power[0])
+        self._top_motor.set_power(power[1])
+
+    def stop_motors(self) -> None:
+        """
+        Stops the feeder's motors
+        """
+        self.set_velocity(FeederSubsystemConstants.STOP_VELOCITY)
 
     def has_piece(self) -> bool:
         """
         Returns the value of either of the piece sensors
 
         Returns:
-            `bool`: whether or not either of the peice sensors are true
+            `bool`: whether or not either of the piece sensors are true
         """
         return not self._entry_piece_sensor.get() or not self._exit_piece_sensor.get()
     
@@ -129,57 +135,57 @@ class FeederSubsystem(Subsystem):
         """
         Prints diagnostics to SmartDashboard
         """
-        _ = SmartDashboard.putNumber("Feeder Pull Motor Target Velocity", self._pull_target_velocity.speed)
-        _ = SmartDashboard.putNumber("Feeder Pull Motor Target Power", self._pull_target_velocity.power)
-        _ = SmartDashboard.putNumber("Feeder Push Motor Target Velocity", self._push_target_velocity.speed)
-        _ = SmartDashboard.putNumber("Feeder Push Motor Target Power", self._push_target_velocity.power)
+        _ = SmartDashboard.putNumber("Feeder Bottom Motor Target Velocity", self._bottom_target_velocity.speed)
+        _ = SmartDashboard.putNumber("Feeder Bottom Motor Target Power", self._bottom_target_velocity.power)
+        _ = SmartDashboard.putNumber("Feeder Top Motor Target Velocity", self._top_target_velocity.speed)
+        _ = SmartDashboard.putNumber("Feeder Top Motor Target Power", self._top_target_velocity.power)
 
         _ = SmartDashboard.putBoolean("Feeder Entry Piece Sensor", not self._entry_piece_sensor.get())
         _ = SmartDashboard.putBoolean("Feeder Exit Piece Sensor", not self._exit_piece_sensor.get())
 
-    def _set_pull_voltage(self, voltage: volts) -> None:
+    def _set_bottom_voltage(self, voltage: volts) -> None:
         '''
         Sets the voltage of the feeder's motors
 
         Parameters:
-            - voltage (`tuple[volts, volts]`): the voltage to set the pull motor to
+            - voltage (`tuple[volts, volts]`): the voltage to set the bottom motor to
         '''
-        self._pull_motor.set_raw_voltage(voltage)
+        self._bottom_motor.set_raw_voltage(voltage)
 
-    def _set_push_voltage(self, voltage: volts) -> None:
+    def _set_top_voltage(self, voltage: volts) -> None:
         '''
         Sets the voltage of the feeder's motors
 
         Parameters:
-            - voltage (`tuple[volts, volts]`): the voltage to set the push motor to
+            - voltage (`tuple[volts, volts]`): the voltage to set the top motor to
         '''
-        self._push_motor.set_raw_voltage(voltage)
+        self._top_motor.set_raw_voltage(voltage)
 
-    def _log_pull_motor(self, log: SysIdRoutineLog) -> None:
+    def _log_bottom_motor(self, log: SysIdRoutineLog) -> None:
         '''
-        Logs the pull motor output for the SysId routine
+        Logs the bottom motor output for the SysId routine
 
         Parameters:
             - log (SysIdRoutineLog): The log to write to
         '''
-        log.motor(f'feeder pull') \
-            .voltage(self._pull_motor.get_raw_voltage()) \
-            .angularPosition(self._pull_motor.get_raw_position()) \
-            .angularVelocity(self._pull_motor.get_raw_velocity())
+        log.motor(f'feeder bottom') \
+            .voltage(self._bottom_motor.get_raw_voltage()) \
+            .angularPosition(self._bottom_motor.get_raw_position()) \
+            .angularVelocity(self._bottom_motor.get_raw_velocity())
         
-    def _log_push_motor(self, log: SysIdRoutineLog) -> None:
+    def _log_top_motor(self, log: SysIdRoutineLog) -> None:
         '''
-        Logs the push motor output for the SysId routine
+        Logs the top motor output for the SysId routine
 
         Parameters:
             - log (SysIdRoutineLog): The log to write to
         '''
-        log.motor(f'feeder push') \
-            .voltage(self._push_motor.get_raw_voltage()) \
-            .angularPosition(self._push_motor.get_raw_position()) \
-            .angularVelocity(self._push_motor.get_raw_velocity())
+        log.motor(f'feeder top') \
+            .voltage(self._top_motor.get_raw_voltage()) \
+            .angularPosition(self._top_motor.get_raw_position()) \
+            .angularVelocity(self._top_motor.get_raw_velocity())
 
-    def get_sysid_command(self, motor: Literal['pull', 'push'], mode: Literal['quasistatic', 'dynamic'], direction: SysIdRoutine.Direction) -> Command:
+    def get_sysid_command(self, motor: Literal['bottom', 'top'], mode: Literal['quasistatic', 'dynamic'], direction: SysIdRoutine.Direction) -> Command:
         '''
         Returns a SysID command for the specified mode and direction
 
@@ -187,13 +193,13 @@ class FeederSubsystem(Subsystem):
             - mode (Literal['quasistatic', 'dynamic']): the mode to run the SysID routine in
             - direction (SysIdRoutine.Direction): the direction to run the SysID routine in
         '''
-        if motor == "pull":
+        if motor == "bottom":
             if mode == "quasistatic":
-                return self._pull_sys_id_routine.quasistatic(direction)
+                return self._bottom_sys_id_routine.quasistatic(direction)
             elif mode == "dynamic":
-                return self._pull_sys_id_routine.dynamic(direction)
-        elif motor == "push":
+                return self._bottom_sys_id_routine.dynamic(direction)
+        elif motor == "top":
             if mode == "quasistatic":
-                return self._push_sys_id_routine.quasistatic(direction)
+                return self._top_sys_id_routine.quasistatic(direction)
             elif mode == "dynamic":
-                return self._push_sys_id_routine.dynamic(direction)
+                return self._top_sys_id_routine.dynamic(direction)

--- a/src/sysid_container.py
+++ b/src/sysid_container.py
@@ -95,7 +95,7 @@ class SysIDContainer():
             print("[SysID Container] Unable to return flywheel SysID commands because FlywheelSubsystem is None")
             return Command()
 
-    def get_feeder_sysid(self, motor: Literal['pull', 'push']) -> Command:
+    def get_feeder_sysid(self, motor: Literal['bottom', 'top']) -> Command:
         """
         Returns a command group that runs the feeder SysID based on the buttons that are pressed
         """

--- a/src/test_container.py
+++ b/src/test_container.py
@@ -29,8 +29,8 @@ class SysIDMode(Enum):
     DRIVETRAIN_DRIVE = 1
     DRIVETRAIN_STEER = 2
     FLYWHEEL = 3
-    FEEDER_PULL = 4
-    FEEDER_PUSH = 5
+    FEEDER_BOTTOM = 4
+    FEEDER_TOP = 5
     TURRET = 6
 
 class TestContainer:
@@ -74,8 +74,8 @@ class TestContainer:
         if self._robot_container.flywheel_subsystem is not None:
             self._sysid_chooser.addOption("Flywheel", SysIDMode.FLYWHEEL)
         if self._robot_container.feeder_subsystem is not None:
-            self._sysid_chooser.addOption("Feeder Pull", SysIDMode.FEEDER_PULL)
-            self._sysid_chooser.addOption("Feeder Push", SysIDMode.FEEDER_PUSH)
+            self._sysid_chooser.addOption("Feeder Bottom", SysIDMode.FEEDER_BOTTOM)
+            self._sysid_chooser.addOption("Feeder Top", SysIDMode.FEEDER_TOP)
         if self._robot_container.turret_subsystem is not None:
             self._sysid_chooser.addOption("Turret", SysIDMode.TURRET)
         SmartDashboard.putData("SysID Mode", self._sysid_chooser)
@@ -147,11 +147,11 @@ class TestContainer:
                     case SysIDMode.FLYWHEEL:
                         return self._sysid_container.get_flywheel_sysid()
 
-                    case SysIDMode.FEEDER_PULL:
-                        return self._sysid_container.get_feeder_sysid("pull")
+                    case SysIDMode.FEEDER_BOTTOM:
+                        return self._sysid_container.get_feeder_sysid("bottom")
 
-                    case SysIDMode.FEEDER_PUSH:
-                        return self._sysid_container.get_feeder_sysid("push")
+                    case SysIDMode.FEEDER_TOP:
+                        return self._sysid_container.get_feeder_sysid("top")
 
                     case SysIDMode.TURRET:
                         return self._sysid_container.get_turret_sysid()


### PR DESCRIPTION
Switched feeder to use a custom datatype for speeds and renamed pull and push motors to bottom and top.  I updated test and sysid but surprisingly this didn't require changing a single command file.